### PR TITLE
Run scheduled jobs as the user who created them

### DIFF
--- a/apps/zipper.run/src/api-handlers/yaml.handler.ts
+++ b/apps/zipper.run/src/api-handlers/yaml.handler.ts
@@ -19,6 +19,7 @@ export default async function handler(request: NextRequest) {
       request,
       version,
       filename,
+      bearerToken: request.headers.get('Authorization')?.replace('Bearer ', ''),
     });
     headers?.set('Content-Type', 'text/yaml');
     return new NextResponse(

--- a/apps/zipper.run/src/utils/relay-middleware.ts
+++ b/apps/zipper.run/src/utils/relay-middleware.ts
@@ -149,7 +149,7 @@ export async function relayRequest({
     appId: app.id,
     deploymentId,
     success: response.status === 200,
-    scheduleId: request.headers.get('X-Zipper-Schedule-Id') || undefined,
+    scheduleId: request.headers.get('x-zipper-schedule-id') || undefined,
     inputs: await getInputFromRequest(request, JSON.stringify(relayBody)),
     result,
   });
@@ -166,6 +166,7 @@ export default async function serveRelay(request: NextRequest) {
     request,
     version,
     filename,
+    bearerToken: request.headers.get('Authorization')?.replace('Bearer ', ''),
   });
   if (request.method !== 'GET')
     headers?.append('Access-Control-Allow-Origin', '*');

--- a/apps/zipper.works/prisma/migrations/20230328205928_add_user_id_to_schedule/migration.sql
+++ b/apps/zipper.works/prisma/migrations/20230328205928_add_user_id_to_schedule/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `schedules` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "schedules" ADD COLUMN     "userId" TEXT NOT NULL;

--- a/apps/zipper.works/prisma/migrations/20230328214104_add_for_scheduled_job_to_access_tokens/migration.sql
+++ b/apps/zipper.works/prisma/migrations/20230328214104_add_for_scheduled_job_to_access_tokens/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "app_access_tokens" ADD COLUMN     "forScheduledJob" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/zipper.works/prisma/migrations/20230328214341_replace_boolean_with_string_for_schedulejobid_on_access_tokens/migration.sql
+++ b/apps/zipper.works/prisma/migrations/20230328214341_replace_boolean_with_string_for_schedulejobid_on_access_tokens/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `forScheduledJob` on the `app_access_tokens` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "app_access_tokens" DROP COLUMN "forScheduledJob",
+ADD COLUMN     "scheduleId" TEXT;

--- a/apps/zipper.works/prisma/schema.prisma
+++ b/apps/zipper.works/prisma/schema.prisma
@@ -54,6 +54,7 @@ model AppAccessToken {
   appId           String
   userId          String
   description     String?
+  scheduleId      String?
 
   app         App       @relation(fields: [appId], references: [id])
 
@@ -182,6 +183,7 @@ model Schedule {
   filename  String    @default("main.ts")
   crontab   String
   inputs    Json?
+  userId    String
 
   appId     String
   app       App?      @relation(fields: [appId], references: [id])

--- a/apps/zipper.works/src/components/app/add-schedule-modal.tsx
+++ b/apps/zipper.works/src/components/app/add-schedule-modal.tsx
@@ -14,14 +14,21 @@ import {
   Button,
   Text,
   Select,
+  CardBody,
+  Card,
+  Divider,
+  HStack,
 } from '@chakra-ui/react';
+import { useUser } from '@clerk/nextjs';
 import { InputParam } from '@zipper/types';
 import { FunctionInputs } from '@zipper/ui';
 import cronstrue from 'cronstrue';
 import { useEffect, useState } from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
 import { parseInputForTypes } from '~/utils/parse-input-for-types';
+import { Avatar } from '../avatar';
 import { useEditorContext } from '../context/editor-context';
+import { useRunAppContext } from '../context/run-app-context';
 
 export type NewSchedule = {
   filename: string;
@@ -67,6 +74,9 @@ export const AddScheduleModal: React.FC<AddScheduleModalProps> = ({
     }
   }, [currentCrontab]);
 
+  const user = useUser();
+  const { appInfo } = useRunAppContext();
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
@@ -83,7 +93,7 @@ export const AddScheduleModal: React.FC<AddScheduleModalProps> = ({
           overflow="auto"
         >
           <FormControl flex={1} display="flex" flexDirection="column">
-            <FormLabel>Scripts</FormLabel>
+            <FormLabel>Script to run</FormLabel>
             <Select
               size="md"
               color="gray.900"
@@ -108,7 +118,7 @@ export const AddScheduleModal: React.FC<AddScheduleModalProps> = ({
             </Select>
           </FormControl>
           <FormControl flex={1} display="flex" flexDirection="column">
-            <FormLabel>Cron expression:</FormLabel>
+            <FormLabel>Schedule (as a cron expression)</FormLabel>
             <Input
               size="md"
               type="text"
@@ -119,16 +129,17 @@ export const AddScheduleModal: React.FC<AddScheduleModalProps> = ({
               {cronString}
             </FormHelperText>
           </FormControl>
-          <VStack
-            alignItems="stretch"
-            flex={1}
-            spacing={3}
-            flexShrink={1}
-            overflow="auto"
-          >
-            {inputParams && (
+
+          {inputParams && inputParams.length > 0 && (
+            <VStack
+              alignItems="stretch"
+              flex={1}
+              spacing={3}
+              flexShrink={1}
+              overflow="auto"
+            >
               <>
-                <Text size="sm">Inputs for this scheduled run:</Text>
+                <FormLabel mb="0">Inputs for this scheduled run:</FormLabel>
                 <VStack
                   flex={1}
                   background="gray.100"
@@ -136,6 +147,7 @@ export const AddScheduleModal: React.FC<AddScheduleModalProps> = ({
                   borderRadius="12"
                   alignItems="stretch"
                   overflow="auto"
+                  mt="0"
                 >
                   <FunctionInputs
                     params={inputParams}
@@ -143,13 +155,17 @@ export const AddScheduleModal: React.FC<AddScheduleModalProps> = ({
                   />
                 </VStack>
               </>
-            )}
-          </VStack>
+            </VStack>
+          )}
           {inputParams === undefined && (
             <Text size="sm">
               This script does not have a main or handler function defined
             </Text>
           )}
+          <HStack border="1px solid" borderColor={'gray.100'} p="2">
+            <Text>This job will be run as </Text>
+            <Text fontWeight={'medium'}>{user.user?.fullName || 'You'}</Text>
+          </HStack>
         </ModalBody>
         <ModalFooter justifyContent="space-between">
           <Button

--- a/apps/zipper.works/src/pages/api/app/info/[slug].ts
+++ b/apps/zipper.works/src/pages/api/app/info/[slug].ts
@@ -208,6 +208,21 @@ async function getUserInfo(token: string, appSlug: string) {
         appAccessToken.hashedSecret,
       );
 
+      // app access tokens with a schedule ID should be deleted after being used
+      if (appAccessToken.scheduleId) {
+        await prisma.appAccessToken.update({
+          where: {
+            identifier_appId: {
+              identifier: appAccessToken.identifier,
+              appId: appAccessToken.appId,
+            },
+          },
+          data: {
+            deletedAt: new Date(Date.now()),
+          },
+        });
+      }
+
       if (!validSecret) throw new Error();
 
       const user = await clerkClient.users.getUser(appAccessToken.userId);

--- a/apps/zipper.works/src/server/routers/appAccessToken.router.ts
+++ b/apps/zipper.works/src/server/routers/appAccessToken.router.ts
@@ -81,10 +81,13 @@ export const appAccessTokenRouter = createRouter()
       identifier: z.string(),
     }),
     async resolve({ ctx, input }) {
-      await prisma.appAccessToken.deleteMany({
+      await prisma.appAccessToken.updateMany({
         where: {
           identifier: input.identifier,
           userId: ctx.userId,
+        },
+        data: {
+          deletedAt: new Date(Date.now()),
         },
       });
 

--- a/apps/zipper.works/src/server/routers/schedule.router.ts
+++ b/apps/zipper.works/src/server/routers/schedule.router.ts
@@ -15,6 +15,7 @@ const defaultSelect = Prisma.validator<Prisma.ScheduleSelect>()({
   filename: true,
   appId: true,
   crontab: true,
+  userId: true,
 });
 
 export const scheduleRouter = createRouter()
@@ -35,7 +36,11 @@ export const scheduleRouter = createRouter()
       const { appId, crontab, inputs, filename } = input;
 
       try {
-        parser.parseExpression(crontab);
+        const parsed = parser.parseExpression(crontab);
+        console.log(parsed.fields.second.toString());
+        if (parsed.fields.second && parsed.fields.second.toString() !== '0') {
+          throw new Error('No seconds allowed');
+        }
       } catch (error) {
         throw new Error('Invalid crontab');
       }
@@ -46,6 +51,7 @@ export const scheduleRouter = createRouter()
           crontab,
           inputs,
           filename,
+          userId: ctx.userId!,
         },
         select: defaultSelect,
       });


### PR DESCRIPTION
If an app requires auth, we'll generate a 1 time use access token belonging to the user who created the scheduled job. We'll pass this token through in the Authorization header when the job runs and delete it as soon as it has been used. 