### PR TITLE
Fix two bugs in the editor: lost changes when switching files & error after deleting files

### DIFF
--- a/apps/zipper.works/src/components/app/app-edit-sidebar.tsx
+++ b/apps/zipper.works/src/components/app/app-edit-sidebar.tsx
@@ -79,7 +79,7 @@ export const AppEditSidebar: React.FC<AppEditSidebarProps> = ({
     appInfo,
   } = useRunAppContext();
 
-  const { currentScript, currentScriptLive, setCurrentScript } =
+  const { currentScript, currentScriptLive, replaceCurrentScriptCode } =
     useEditorContext();
 
   const router = useRouter();
@@ -263,11 +263,7 @@ export const AppEditSidebar: React.FC<AppEditSidebarProps> = ({
   const handleAddInput = () => {
     if (currentScriptLive && currentScript) {
       const codeWithInputAdded = addParamToCode(currentScriptLive?.code || '');
-
-      setCurrentScript({
-        ...currentScript,
-        code: codeWithInputAdded,
-      });
+      replaceCurrentScriptCode(codeWithInputAdded);
     }
   };
   return (

--- a/apps/zipper.works/src/components/context/editor-context.tsx
+++ b/apps/zipper.works/src/components/context/editor-context.tsx
@@ -35,6 +35,7 @@ export type EditorContextType = {
   setIsSaving: (isSaving: boolean) => void;
   save: () => Promise<void>;
   refetchApp: VoidFunction;
+  replaceCurrentScriptCode: (code: string) => void;
 };
 
 export const EditorContext = createContext<EditorContextType>({
@@ -54,6 +55,7 @@ export const EditorContext = createContext<EditorContextType>({
   setIsSaving: noop,
   save: asyncNoop,
   refetchApp: noop,
+  replaceCurrentScriptCode: noop,
 });
 
 const EditorContextProvider = ({
@@ -167,8 +169,9 @@ const EditorContextProvider = ({
 
   const self = useSelf();
 
-  useEffect(() => {
+  const replaceCurrentScriptCode = (code: string) => {
     if (currentScript) {
+      setCurrentScript({ ...currentScript, code });
       const models = editor?.getModels();
       if (models) {
         const fileModels = models.filter(
@@ -194,7 +197,8 @@ const EditorContextProvider = ({
         });
       }
     }
-  }, [editor, currentScript]);
+  };
+
   const saveOpenModels = async () => {
     if (appId && currentScript) {
       setIsSaving(true);
@@ -276,6 +280,7 @@ const EditorContextProvider = ({
         setIsSaving,
         save: saveOpenModels,
         refetchApp,
+        replaceCurrentScriptCode,
       }}
     >
       {children}


### PR DESCRIPTION
Noticed a bug that changes were lost when switching between files. Tracked it down to a useEffect in the editorContext that was replacing the currentScript with the code from the db every time the currentScript was changed. Related PR #51 

There was also a minor bug where we tried to update a script that had been deleted which resulted in an error