### PR TITLE
if the version is `latest` then we use the lastDeployedVersion

### DIFF
--- a/apps/zipper.run/src/components/app.tsx
+++ b/apps/zipper.run/src/components/app.tsx
@@ -50,7 +50,7 @@ export function AppPage({
   app,
   inputs,
   userAuthConnectors,
-  version = app?.lastDeploymentVersion || Date.now().toString(32),
+  version = 'latest',
   filename,
   defaultValues,
   slackAuthUrl,
@@ -358,10 +358,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const { app, inputs, userAuthConnectors } = result.data;
 
-  const version =
-    versionFromUrl ||
-    app.lastDeploymentVersion?.toString() ||
-    Date.now().toString();
+  const version = versionFromUrl || 'latest';
 
   const defaultValues = getInputValuesFromUrl(inputs, req.url);
   if (__DEBUG__) console.log({ defaultValues });

--- a/apps/zipper.works/src/utils/get-run-url.ts
+++ b/apps/zipper.works/src/utils/get-run-url.ts
@@ -1,6 +1,6 @@
 export default function getRunUrl(
   slug: string,
-  version: string | null | undefined = Date.now().toString(32),
+  version: string | null | undefined = 'latest',
   filename?: string,
 ) {
   const path = `run/${slug}/${version}/${filename || 'main.ts'}`;


### PR DESCRIPTION
The run server defaults to using `latest` if no version is specified. This means that you'll get the last deploy each time you click run, regardless of whether you reloaded the page