### PR TITLE
changes on the query and types to return apps even without resourceOwner

### DIFF
--- a/apps/zipper.works/src/server/routers/app.router.ts
+++ b/apps/zipper.works/src/server/routers/app.router.ts
@@ -332,13 +332,11 @@ export const appRouter = createRouter()
               r.resourceOwnerId === (app.organizationId || app.createdById),
           );
 
-          if (resourceOwner) {
-            arr.push({ ...app, resourceOwner });
-          }
+          arr.push(resourceOwner ? { ...app, resourceOwner } : app);
           return arr;
         },
         // prettier-ignore
-        [] as (typeof apps[0] & { resourceOwner: ResourceOwnerSlug })[],
+        [] as (typeof apps[0] & Partial<{ resourceOwner: ResourceOwnerSlug }>)[],
       );
     },
   })


### PR DESCRIPTION
Hey everyone, I noticed that apps created in a user's personal workspace were not showing up in the query results. After investigating the 'app.byAuthedUser' query, I made some changes to include apps that don't have a resourceOwnerSlug.

However, I noticed that this modification might introduce breaking changes in the use-app-owner hook and the dashboard/index.tsx component

I've created this draft PR to start a discussion about the potential impact of these changes and get your thoughts on how we can address any issues that might arise.

Notes:
- I've observed possible breaking changes to the use-app-owner hook due to the updated query.
- The dashboard/index.tsx component's Link block might also be affected by these changes.

Let me know what you think about this suggestion and the possible consequences. Looking forward to hearing your thoughts!

@imadha 
@sachinr 
@fawz24 