### PR TITLE
Minor action button fixes

### DIFF
--- a/packages/@zipper-ui/src/components/function-output/action-button.tsx
+++ b/packages/@zipper-ui/src/components/function-output/action-button.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Spinner } from '@chakra-ui/react';
+import { Button, Flex, Spinner } from '@chakra-ui/react';
 import { useState } from 'react';
 import { Action } from './action-component';
 import { FunctionOutputProps } from './types';
@@ -14,10 +14,11 @@ export function ActionButton({
     const res = await fetch(getRunUrl(action.script), {
       method: 'POST',
       body: JSON.stringify(action.inputs || []),
+      credentials: 'include',
     });
     const text = await res.text();
 
-    switch (action.showAs) {
+    switch (action.show_as) {
       case 'modal':
         setModalResult({ heading: `${action.script}`, body: text });
         break;

--- a/packages/@zipper-ui/src/components/function-output/action-component.tsx
+++ b/packages/@zipper-ui/src/components/function-output/action-component.tsx
@@ -5,7 +5,7 @@ export type Action = {
   action_type: string;
   text: string;
   script: string;
-  showAs: 'modal' | 'expanded' | 'replace_all';
+  show_as: 'modal' | 'expanded' | 'replace_all';
   inputs: Record<string, any>;
 };
 


### PR DESCRIPTION
Two changes: 
1. Renamed `showAs` in the button configuration to `show_as` since it's JSON
2. Included credentials of the currently authed user in the button fetch so that scripts that are behind auth work