### PR TITLE
Handle authed user runs 

### DIFF
--- a/apps/zipper.run/src/components/app.tsx
+++ b/apps/zipper.run/src/components/app.tsx
@@ -159,10 +159,6 @@ export function AppPage({
     );
   };
 
-  if (statusCode === 401) {
-    return <Unauthorized />;
-  }
-
   const connectorActions: Record<ConnectorType, ConnectorActionProps> = {
     github: {
       authUrl: githubAuthUrl || '#',
@@ -198,12 +194,16 @@ export function AppPage({
   const showRunOutput = (['edit', 'run'] as Screen[]).includes(screen);
 
   const canRunApp = useMemo(() => {
-    return userAuthConnectors.every((connector) => {
+    return (userAuthConnectors || []).every((connector) => {
       return (
         connector.appConnectorUserAuths && connector.appConnectorUserAuths[0]
       );
     });
   }, [userAuthConnectors]);
+
+  if (statusCode === 401) {
+    return <Unauthorized />;
+  }
 
   return (
     <>

--- a/apps/zipper.works/src/pages/api/appRun/[slug]/[runId].ts
+++ b/apps/zipper.works/src/pages/api/appRun/[slug]/[runId].ts
@@ -93,25 +93,29 @@ export default async function handler(
     entryPoint = appRun.app.scripts.find((s) => s.filename === 'main.ts');
   }
 
+  let result: any = appRun.result;
+
   if (appRun.userId) {
     // return 401 if there's no token or no user was found by getUserInfo()
     if (!token || !userInfo.clerkUserId) {
-      return res.status(401).send({
-        ok: false,
-        error: 'UNAUTHORIZED',
-      });
+      return res.status(401).send({ ok: false, error: 'UNAUTHORIZED' });
+    }
+
+    if (appRun.userId !== userInfo.clerkUserId) {
+      result =
+        "You're not authorized to view this run. Try re-running the app.";
     }
   }
 
   const { id, name, slug, description, updatedAt, scripts } = appRun.app;
 
-  const result: RunInfoResult = {
+  const runInfoResult: RunInfoResult = {
     ok: true,
     data: {
       appRun: {
         path: appRun.path,
         version: appRun.version || 'latest',
-        result: appRun.result || '',
+        result,
         inputs: appRun.inputs as Record<string, string>,
       },
       app: {
@@ -145,7 +149,7 @@ export default async function handler(
     },
   };
 
-  return res.status(200).send(result);
+  return res.status(200).send(runInfoResult);
 }
 
 /* There are two types of auth tokens that can be used to run an app:

--- a/apps/zipper.works/src/pages/api/appRun/create.ts
+++ b/apps/zipper.works/src/pages/api/appRun/create.ts
@@ -20,6 +20,7 @@ export default async function handler(
         originalRequestUrl: rpcBody.originalRequest.url,
         originalRequestMethod: rpcBody.originalRequest.method,
         version: rpcBody.appInfo.version,
+        userId: rpcBody.userInfo?.userId,
         success,
         result,
       },


### PR DESCRIPTION
If an app requires auth, attach the current user's userId to the appRun. Only let that user see the run result. Other authed users can see the inputs that were used for the run so they can re-run it themselves. Unauthed users will be shown a 401 so they can auth and try access the app run again. 