### PR TITLE
Bring Monaco editor's hover widget on top of everything

### DIFF
--- a/apps/zipper.works/src/components/app/playground-editor.tsx
+++ b/apps/zipper.works/src/components/app/playground-editor.tsx
@@ -290,6 +290,7 @@ export default function PlaygroundEditor(
           automaticLayout: true,
           scrollbar: { verticalScrollbarSize: 0, horizontalScrollbarSize: 0 },
           readOnly: !appInfo.canUserEdit,
+          fixedOverflowWidgets: true,
         }}
         overrideServices={{
           openerService: {


### PR DESCRIPTION
## Changes Summary

set monaco editor overflow widgets' display to fixed

![image](https://user-images.githubusercontent.com/19811530/233410658-e7ac6dab-85cb-424f-a93b-228d12f4c19b.png)
