### PR TITLE
Remove avatars from the History tab

### DIFF
--- a/apps/zipper.dev/src/components/app/history-tab.tsx
+++ b/apps/zipper.dev/src/components/app/history-tab.tsx
@@ -24,14 +24,8 @@ import {
   DrawerCloseButton,
   DrawerBody,
 } from '@chakra-ui/react';
-import { Avatar } from '../avatar';
 import { useRouter } from 'next/router';
-import {
-  HiExclamationTriangle,
-  HiCheck,
-  HiMagnifyingGlass,
-  HiMagnifyingGlassPlus,
-} from 'react-icons/hi2';
+import { HiExclamationTriangle, HiCheck } from 'react-icons/hi2';
 import { TbClockPlay } from 'react-icons/tb';
 import {
   createColumnHelper,
@@ -121,18 +115,8 @@ const HistoryTab: React.FC<HistoryTabProps> = ({ appId }) => {
         id: 'user',
         size: 100,
         header: 'Run by',
-        cell: ({
-          getValue,
-          row: {
-            original: { userId },
-          },
-        }) => {
-          return (
-            <HStack>
-              {userId && <Avatar userId={userId} size="xs" />}
-              <Text>{getValue()}</Text>
-            </HStack>
-          );
+        cell: ({ getValue }) => {
+          return <Text>{getValue()}</Text>;
         },
       },
     ),


### PR DESCRIPTION
We're doing an API call to Clerk for every single avatar and as a result, we're getting rate limited. If we want to add this functionality back, we need to cache avatars or figure out Clerk's naming scheme for images