### PR TITLE
Add post install script to install browser for Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "db-nuke": "docker-compose down --volumes --remove-orphans",
     "ts-node": "ts-node -T",
     "deno:dev": "yarn dotenv -c .env.local ts-node --compiler-options \"{\\\"module\\\":\\\"commonjs\\\"}\" ./bin/ts/deno-dev.ts",
-    "deno:deploy": "yarn dotenv -c .env.local ts-node --compiler-options \"{\\\"module\\\":\\\"commonjs\\\"}\" ./bin/ts/deno-deploy.ts"
+    "deno:deploy": "yarn dotenv -c .env.local ts-node --compiler-options \"{\\\"module\\\":\\\"commonjs\\\"}\" ./bin/ts/deno-deploy.ts",
+    "postinstall": "npx playwright install"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
For fresh installs (like ours on Render), a followup `npx` script is required to install the browsers for Playwright. This PR adds that via the `"postinstall"` key in package.json.