### PR TITLE
Add post install script to install browser for Playwright

### DIFF
--- a/apps/zipper.run/package.json
+++ b/apps/zipper.run/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --port 3002",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "npx playwright install"
   },
   "prettier": {
     "printWidth": 80,


### PR DESCRIPTION
This PR adds the `postinstall` script for Playwright, to zipper-run this time.