### PR TITLE
chore: improve Zipper.Storage types

### DIFF
--- a/packages/@zipper-framework/deno/lib/storage.ts
+++ b/packages/@zipper-framework/deno/lib/storage.ts
@@ -26,9 +26,8 @@ export class ZipperStorage<Value extends Zipper.Serializable> implements Zipper.
     this.appId = appId;
   }
 
-  async get(key?: string) {
-    let path = `/api/app/${this.appId}/storage`;
-    if (key) path += '?key=' + key;
+  async getAll() {
+    const path = `/api/app/${this.appId}/storage`;
     const { hmac, timestamp } = generateHmac('GET', path);
 
     const res = await fetch(Deno.env.get('RPC_HOST') + path, {
@@ -36,10 +35,22 @@ export class ZipperStorage<Value extends Zipper.Serializable> implements Zipper.
     });
 
     const result = await res.json();
-    return key ? result.value : result;
+    return result;
   }
 
-  async set(key: string, value: unknown) {
+  async get(key: string) {
+    const path = `/api/app/${this.appId}/storage?key=${key}`;
+    const { hmac, timestamp } = generateHmac('GET', path);
+
+    const res = await fetch(Deno.env.get('RPC_HOST') + path, {
+      headers: { 'x-zipper-hmac': hmac, 'x-timestamp': timestamp },
+    });
+
+    const result = await res.json();
+    return result.value
+  }
+
+  async set(key: string, value: Value) {
     const path = `/api/app/${this.appId}/storage`;
     const { hmac, timestamp } = generateHmac('POST', path, { key, value });
 

--- a/packages/@zipper-framework/deno/zipper.d.ts
+++ b/packages/@zipper-framework/deno/zipper.d.ts
@@ -337,6 +337,7 @@ declare namespace Zipper {
    */
   export interface Storage<Value extends Serializable> {
     appId: string;
+    getAll(): Promise<any[]>;
     get(key: string): Promise<any>;
     set(key: string, value: Value): Promise<{key: string, value: any}>;
     delete(key: string): Promise<true>;
@@ -421,7 +422,7 @@ declare namespace Zipper {
    *
    * @example
    * // get all values in storage
-   * const allValues = await Zipper.storage.get();
+   * const allValues = await Zipper.storage.getAll();
    *
    * // get a single valueby key
    * const singleValue = await Zipper.storage.get('my-storage-key');
@@ -432,7 +433,7 @@ declare namespace Zipper {
    * // delete a value by key
    * await Zipper.storage.delete('another-store-key');
    */
-  export const storage: Storage;
+  export const storage: Storage<Serializable>;
 }
 
 // Global components


### PR DESCRIPTION
Since we're writing storage values in DB, these values needs to be serialized.
Previously, if you try to call `Zipper.storage.set('foo', () => 'bar')` you would get `true`, but nothing would be wrote to DB.

**BREAKING CHANGE**: `get() -> getAll()`: This allow us to explicitly say that getAll returns an array of values
Of course, `.get(key: string)` still the same