### PR TITLE
only use the custom slack_client_secret if there's a custom client id

### DIFF
--- a/apps/zipper.dev/src/pages/connectors/slack/auth.tsx
+++ b/apps/zipper.dev/src/pages/connectors/slack/auth.tsx
@@ -1,13 +1,14 @@
 import { Center, Text, VStack } from '@chakra-ui/react';
 import { ZipperLogo } from '@zipper/ui';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { NextPageWithLayout } from '~/pages/_app';
 import { trpc } from '~/utils/trpc';
 
 const SlackAuth: NextPageWithLayout = () => {
   const router = useRouter();
   const { code, state, error, error_description } = router.query;
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
   const exchangeMutation = trpc.useMutation(
     'slackConnector.exchangeCodeForToken',
@@ -19,15 +20,18 @@ const SlackAuth: NextPageWithLayout = () => {
           router.push(data.redirectTo || `/app/${data.appId}/edit/main.ts`);
         }
       },
+      onError: (error) => {
+        setErrorMessage(error.message);
+      },
     },
   );
 
-  if (error) {
+  if (error || errorMessage) {
     return (
       <Center w="100%" h="100vh">
         <VStack spacing="12">
           <ZipperLogo />
-          <Text>{error_description}</Text>
+          <Text>{error_description || errorMessage}</Text>
         </VStack>
       </Center>
     );

--- a/apps/zipper.dev/src/server/routers/slackConnector.router.ts
+++ b/apps/zipper.dev/src/server/routers/slackConnector.router.ts
@@ -196,14 +196,16 @@ export const slackConnectorRouter = createRouter()
         },
       });
 
-      const clientId =
-        appConnector?.clientId || process.env.NEXT_PUBLIC_SLACK_CLIENT_ID!;
-      const clientSecret = clientSecretRecord
-        ? decryptFromBase64(
-            clientSecretRecord.encryptedValue,
-            process.env.ENCRYPTION_KEY,
-          )
-        : process.env.SLACK_CLIENT_SECRET!;
+      let clientId = process.env.NEXT_PUBLIC_SLACK_CLIENT_ID!;
+      let clientSecret = process.env.SLACK_CLIENT_SECRET!;
+
+      if (appConnector?.clientId && clientSecretRecord) {
+        clientId = appConnector?.clientId;
+        clientSecret = decryptFromBase64(
+          clientSecretRecord.encryptedValue,
+          process.env.ENCRYPTION_KEY,
+        );
+      }
 
       const res = await fetch('https://slack.com/api/oauth.v2.access', {
         method: 'POST',
@@ -222,7 +224,7 @@ export const slackConnectorRouter = createRouter()
       if (!json.ok) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
-          message: json.error,
+          message: `Something went wrong while exchanging the code for a token: ${json.error}`,
         });
       }
 


### PR DESCRIPTION
Noticed a bug where an old custom client_secret was being used even though the slack connector didn't have a custom slack id set