### PR TITLE
App edit authz check was only checking the current org membership

### DIFF
--- a/apps/zipper.dev/src/server/utils/authz.utils.ts
+++ b/apps/zipper.dev/src/server/utils/authz.utils.ts
@@ -9,7 +9,7 @@ export const hasAppEditPermission = async ({
   ctx: Context;
   appId: string;
 }) => {
-  const { userId, orgId } = ctx;
+  const { userId, organizations } = ctx;
   if (!userId) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
   }
@@ -23,7 +23,7 @@ export const hasAppEditPermission = async ({
             editors: { some: { userId } },
           },
           {
-            organizationId: orgId,
+            organizationId: { in: Object.keys(organizations || {}) },
           },
         ],
       },
@@ -59,7 +59,7 @@ export const hasAppReadPermission = async ({
                 },
               },
               {
-                organizationId: ctx.orgId,
+                organizationId: { in: Object.keys(ctx.organizations || {}) },
               },
             ],
           },


### PR DESCRIPTION
But we should be checking whether you have edit access based on all your org memberships... 