### PR TITLE
Build and save every version to the DB

### DIFF
--- a/apps/zipper.dev/src/components/app/playground-header.tsx
+++ b/apps/zipper.dev/src/components/app/playground-header.tsx
@@ -331,7 +331,6 @@ export function PlaygroundHeader({ app }: { app: AppQueryOutput }) {
                   type="submit"
                   isDisabled={isDisabled}
                   onClick={forkAppForm.handleSubmit(async ({ name }) => {
-                    if (app.canUserEdit) return;
                     if (user) {
                       if (
                         (selectedOrganizationId ?? null) !==


### PR DESCRIPTION
This is take two at implementing a way to publish changes from the playground to the zipper.run url. The approach this time is to: 
* Create an ESZip binary on save
* Save each ESZip binary to a `versions` table using the hash of the code as the id
* Save the hash to the `apps` table so we know which binary maps to the last playground save
* On publish, save the last hash to the apps table as the `publishedVersionHash`
* When zipper.run is run with `latest` version, we use the ESZip build associated with the publishedVersionHash

The follow up to this PR will be to move old playground versions to S3 so that we're not shoving a ton of data into our db. 