### PR TITLE
Fix hardcoded description on unfurls

### DIFF
--- a/apps/zipper.run/src/components/applet.tsx
+++ b/apps/zipper.run/src/components/applet.tsx
@@ -296,7 +296,11 @@ export function AppPage({
     <>
       <Head>
         <title>{appTitle}</title>
-        <OpenGraph appTitle={appTitle} runUrl={runUrl} />
+        <OpenGraph
+          title={appTitle}
+          description={app.description || app.slug}
+          url={runUrl}
+        />
       </Head>
       <VStack flex={1} alignItems="stretch" spacing={14}>
         <Header

--- a/apps/zipper.run/src/components/open-graph.tsx
+++ b/apps/zipper.run/src/components/open-graph.tsx
@@ -1,20 +1,21 @@
 export type OpenGraphProps = {
-  appTitle: string;
-  runUrl?: string;
+  title: string;
+  description?: string;
+  url?: string;
 };
 
-export function OpenGraph({ appTitle, runUrl }: OpenGraphProps) {
-  const imagePreviewUrl = `${runUrl}.png`;
+export function OpenGraph({ title, description, url }: OpenGraphProps) {
+  const imagePreviewUrl = `${url}.png`;
   return (
     <>
-      <meta name="description" content="The Description" />
-      <meta property="og:title" content={appTitle} />
-      <meta property="og:description" content="The Description" />
+      <meta name="description" content={description} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
       <meta property="og:site_name" content="Zipper" />
       <meta property="og:type" content="website" />
-      {runUrl && (
+      {url && (
         <>
-          <meta property="og:url" content={runUrl} />
+          <meta property="og:url" content={url} />
           <meta property="og:image" content={imagePreviewUrl} />
         </>
       )}


### PR DESCRIPTION
Previously the `<OpenGraph>` component hardcoded "The Description" for the description. This PR plumbs the app description through for Run URLs, defaulting to the app slug.