### PR TITLE
serve the relay when POSTing to root run url

### DIFF
--- a/apps/zipper.run/src/middleware.ts
+++ b/apps/zipper.run/src/middleware.ts
@@ -59,8 +59,10 @@ async function maybeGetCustomResponse(
         return NextResponse.rewrite(url, { request: { headers } });
       }
       if (request.method === 'POST') {
-        const url = new URL('/relay', request.url);
-        return NextResponse.rewrite(url, { request: { headers } });
+        return serveRelay({
+          request,
+          bootOnly: false,
+        });
       }
     }
   }


### PR DESCRIPTION
This change means that you'll get raw JSON back when POSTing to the zipper.run URL of an applet. If you want to get the JSON wrapped in the nice API stuff we do, then you can still use /api. 