### PR TITLE
add an html handler to the middleware on zipper.run

### DIFF
--- a/apps/zipper.run/src/api-handlers/html.handler.ts
+++ b/apps/zipper.run/src/api-handlers/html.handler.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFilenameAndVersionFromPath } from '~/utils/get-values-from-url';
+import { relayRequest } from '~/utils/relay-middleware';
+
+export default async function htmlHandler(request: NextRequest) {
+  const { version, filename } = getFilenameAndVersionFromPath(
+    request.nextUrl.pathname,
+    ['api/html'],
+  );
+
+  const { result, status, headers } = await relayRequest({
+    request,
+    version,
+    filename,
+  });
+
+  headers?.set('Content-Type', 'text/html');
+
+  headers?.set('Access-Control-Allow-Origin', '*');
+  headers?.set(
+    'Access-Control-Allow-Methods',
+    'GET, POST, PUT, DELETE, OPTIONS',
+  );
+  headers?.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (status === 404) {
+    return NextResponse.rewrite(new URL('/404', request.url));
+  }
+
+  if (status >= 500) {
+    return new NextResponse(`Error: ${result}`, {
+      status,
+      headers,
+    });
+  }
+
+  return new NextResponse(result, {
+    status,
+    headers,
+  });
+}

--- a/apps/zipper.run/src/middleware.ts
+++ b/apps/zipper.run/src/middleware.ts
@@ -3,12 +3,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import serveRelay from './utils/relay-middleware';
 import jsonHandler from './api-handlers/json.handler';
 import yamlHandler from './api-handlers/yaml.handler';
+import htmlHandler from './api-handlers/html.handler';
+
 import {
   getZipperApiUrl,
   ZIPPER_TEMP_USER_ID_COOKIE_NAME,
 } from '@zipper/utils';
 import { jwtVerify } from 'jose';
-import htmlHandler from './api-handlers/html.handler';
 
 const { __DEBUG__ } = process.env;
 


### PR DESCRIPTION
Adding an api endpoint to zipper.run that allows us to return html. This is necessary to build Zendesk integrations that iframe content from an applet. 