### PR TITLE
set min width on dashboard icons

### DIFF
--- a/apps/zipper.dev/src/components/dashboard/index.tsx
+++ b/apps/zipper.dev/src/components/dashboard/index.tsx
@@ -84,7 +84,7 @@ const columns = [
     }) => {
       return (
         <HStack align="center" spacing={4}>
-          <Box clipPath={'circle(32px)'} w="12">
+          <Box clipPath={'circle(32px)'} w="12" minW="12">
             <AppAvatar nameOrSlug={slug} />
           </Box>
           <VStack align={'start'}>


### PR DESCRIPTION
Noticed that the dashboard app icons where getting really small is there is a long description

<img width="375" alt="image" src="https://github.com/Zipper-Inc/zipper-functions/assets/700173/07bbcf4a-c762-4230-8db9-0d4fccd6721b">
