### PR TITLE
add /raw endpoint

### DIFF
--- a/apps/zipper.run/src/utils/relay-middleware.ts
+++ b/apps/zipper.run/src/utils/relay-middleware.ts
@@ -237,7 +237,7 @@ export default async function serveRelay({
 }) {
   const { version, filename } = getFilenameAndVersionFromPath(
     request.nextUrl.pathname,
-    bootOnly ? ['boot'] : ['relay'],
+    bootOnly ? ['boot'] : ['relay', 'raw'],
   );
 
   console.log('version: ', version);


### PR DESCRIPTION
Originally thought that we would allow people to POST to any zipper.run URL and get back JSON but this caused a bunch of problems. Adding a /raw endpoint as an alternative for now