### PR TITLE
fix quotes in input type's keys breaking the UI

### DIFF
--- a/apps/zipper.dev/src/components/app/app-edit-sidebar.tsx
+++ b/apps/zipper.dev/src/components/app/app-edit-sidebar.tsx
@@ -10,7 +10,6 @@ import {
   HStack,
   Heading,
   useColorMode,
-  Code,
 } from '@chakra-ui/react';
 import { TabButton } from '@zipper/ui';
 import { useState } from 'react';

--- a/packages/@zipper-utils/src/utils/form.ts
+++ b/packages/@zipper-utils/src/utils/form.ts
@@ -7,7 +7,7 @@ import { InputType } from '@zipper/types';
  * @returns
  */
 export const getFieldName = (name: string, type: InputType) =>
-  `${name}:${type}`;
+  `${name.replaceAll(`"`, '')}:${type}`;
 
 /**
  * `parseFieldName` parses a given form field name


### PR DESCRIPTION
Prior to this change, the following code would cause an error from ReactHookForm to bubble up and stop the playground from loading

```
type CustomType = {
  "test": number;
};

export async function handler(event: CustomType) {
  return event.test;
}
```