### PR TITLE
attempt to fix json parsing for any type in the playground

### DIFF
--- a/apps/zipper.dev/src/components/context/run-app-context.tsx
+++ b/apps/zipper.dev/src/components/context/run-app-context.tsx
@@ -220,6 +220,14 @@ export function RunAppProvider({
     const runStart = performance.now();
     const formValues = formMethods.getValues();
 
+    // ReactHookForm doesn't parse destructured objects correctly i.e. { ...foo }: any
+    // this is a hack but we should fix it upstream
+    if (Object.keys(formValues).includes('{ ')) {
+      const badlyParsedKey = Object.keys(formValues['{ '])[0];
+      if (badlyParsedKey) {
+        formValues[`{ ...${badlyParsedKey}`] = formValues['{ '][badlyParsedKey];
+      }
+    }
     const inputs = getInputsFromFormData(formValues, inputParams);
     const hasInputs = inputs && Object.values(inputs).length;
 

--- a/packages/@zipper-types/src/types/input-type.ts
+++ b/packages/@zipper-types/src/types/input-type.ts
@@ -14,4 +14,5 @@ export const JSONEditorInputTypes = [
   InputType.array,
   InputType.object,
   InputType.any,
+  InputType.unknown,
 ];

--- a/packages/@zipper-utils/src/utils/object.ts
+++ b/packages/@zipper-utils/src/utils/object.ts
@@ -8,7 +8,9 @@ export const getInputsFromFormData = (
 ) => {
   const formKeys = inputParams.map(({ key, type }) => getFieldName(key, type));
   return Object.keys(formData)
-    .filter((k) => formKeys.includes(k))
+    .filter((k) => {
+      return formKeys.includes(k);
+    })
     .reduce((acc, cur) => {
       const { name, type } = parseFieldName(cur);
 
@@ -22,6 +24,10 @@ export const getInputsFromFormData = (
 
       if (type === InputType.boolean) {
         value = !!value;
+      }
+
+      if (name.startsWith('{')) {
+        return { ...acc, ...value };
       }
 
       return { ...acc, [name]: value };


### PR DESCRIPTION
Hacky fix to the fact that ReactHookForm can't handle fields names that include `{ ...something }`. Also includes a fix where we weren't destructuring the json input when running the applet from the playground. 