### PR TITLE
[Docs] Reset Chakra's theme to Tailwind's

### DIFF
--- a/apps/docs/pages/_app.tsx
+++ b/apps/docs/pages/_app.tsx
@@ -3,6 +3,10 @@ import { AppProps } from 'next/app';
 import { theme } from '@zipper/ui';
 
 function MyApp(props: AppProps) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('chakra-ui-color-mode', localStorage.getItem('theme'));
+  }
+
   return (
     <ChakraProvider theme={theme}>
       <props.Component {...props.pageProps} />


### PR DESCRIPTION
Things look really broken if Chakra is set to dark mode but Tailwind isn't. This PR just resets Chakra's theme to use Tailwind's 