### PR TITLE
fix: fixing blockquote styles on markdown

### DIFF
--- a/packages/@zipper-ui/src/utils/chakra-markdown-renderer.tsx
+++ b/packages/@zipper-ui/src/utils/chakra-markdown-renderer.tsx
@@ -118,16 +118,8 @@ export const defaults: Components & { heading: Components['h1'] } = {
   blockquote: (props) => {
     const { children } = props;
 
-    const isNestedBlockquote = children.some((child: any) => {
-      return child.props?.node?.tagName === 'blockquote';
-    });
-
     return (
-      <Box
-        borderRadius={8}
-        bgColor={isNestedBlockquote ? 'fg.50' : 'white'}
-        p={4}
-      >
+      <Box borderRadius={8} bgColor={'fg.50'} p={4}>
         <Text
           position="relative"
           _before={{


### PR DESCRIPTION
Fixing colors in Blockquotes on markdown 
<img width="695" alt="image" src="https://github.com/Zipper-Inc/zipper-functions/assets/17475188/9b60d722-ea83-4884-b40e-8f055e1b679c">
