### PR TITLE
Give developers more control over buttons

### DIFF
--- a/packages/@zipper-framework/deno/zipper.d.ts
+++ b/packages/@zipper-framework/deno/zipper.d.ts
@@ -228,6 +228,12 @@ declare namespace Zipper {
     | 'self-start'
     | 'start';
 
+  export interface ButtonComponentProps {
+    width?: string;
+    colorScheme?: 'purple' | 'blue' | 'red' | 'green' | 'yellow';
+    variant?: 'outline' | 'solid' | 'link' | 'ghost';
+  }
+
   export interface StackComponent extends ComponentBase {
     type: 'stack';
     props?:
@@ -455,7 +461,7 @@ declare function Link(props: LinkProps): Zipper.Component;
 
 type ButtonProps<I> = Omit<Zipper.ButtonAction<I>, 'actionType' | 'text'>;
 declare function Button<I = Zipper.Inputs>(
-  props: ButtonProps<I>,
+  props: ButtonProps<I> & Zipper.ButtonComponentProps,
 ): Zipper.Action;
 
 type MarkdownProps = { text?: string };

--- a/packages/@zipper-ui/src/components/function-output/action-button.tsx
+++ b/packages/@zipper-ui/src/components/function-output/action-button.tsx
@@ -9,7 +9,11 @@ import { AppInfoResult, InputParam, InputParams } from '@zipper/types';
 import { SmartFunctionOutputContext } from './smart-function-output-context';
 import Zipper from '../../../../@zipper-framework';
 
-export function ActionButton({ action }: { action: Zipper.ButtonAction }) {
+export function ActionButton({
+  action,
+}: {
+  action: Zipper.ButtonAction & Zipper.ButtonComponentProps;
+}) {
   const {
     showSecondaryOutput,
     getRunUrl,
@@ -139,10 +143,10 @@ export function ActionButton({ action }: { action: Zipper.ButtonAction }) {
 
   return (
     <Button
-      colorScheme={'purple'}
-      variant="outline"
+      colorScheme={action.colorScheme || 'purple'}
+      w={action.width || 'fit-content'}
+      variant={action.variant || 'outline'}
       isDisabled={isLoading}
-      mr="2"
       onClick={async () => {
         setIsLoading(true);
         action.run


### PR DESCRIPTION
You can now customize the width, color, and variant of the button. This allows you to have different types of buttons for things like create and delete.