### PR TITLE
feat: adding the ability to render img component

### DIFF
--- a/packages/@zipper-ui/src/components/function-output/smart-function-output.tsx
+++ b/packages/@zipper-ui/src/components/function-output/smart-function-output.tsx
@@ -153,6 +153,30 @@ export function SmartFunctionOutput({
           const defaultElement =
             defaultElements[element as keyof typeof defaultElements];
 
+          // Check if the element is a void element
+          const voidElements = [
+            'area',
+            'base',
+            'br',
+            'col',
+            'command',
+            'embed',
+            'hr',
+            'img',
+            'input',
+            'keygen',
+            'link',
+            'meta',
+            'param',
+            'source',
+            'track',
+            'wbr',
+          ];
+
+          if (voidElements.includes(element)) {
+            return React.createElement(defaultElement || element, props);
+          }
+
           return React.createElement(
             defaultElement || element,
             props,


### PR DESCRIPTION
Adding the ability to render <img /> components and other void html components into zipper 
![image](https://github.com/Zipper-Inc/zipper-functions/assets/17475188/e2b90f72-e766-4057-babc-3f8637d7d173)
