### PR TITLE
adding validation if slug isnt valid and blocking user to move forward

### DIFF
--- a/apps/zipper.dev/src/components/dashboard/create-app-form.tsx
+++ b/apps/zipper.dev/src/components/dashboard/create-app-form.tsx
@@ -377,7 +377,7 @@ export const CreateAppForm: React.FC<{ onClose: () => void }> = ({
                       <InputRightElement
                         children={
                           slugExists ? (
-                            <WarningIcon color="red.500" />
+                            <Icon as={HiExclamationTriangle} color="red.500" />
                           ) : (
                             <CheckIcon color="green.500" />
                           )
@@ -385,7 +385,9 @@ export const CreateAppForm: React.FC<{ onClose: () => void }> = ({
                       />
                     ) : (
                       <InputRightElement
-                        children={<WarningIcon color="red.500" />}
+                        children={
+                          <Icon as={HiExclamationTriangle} color="red.500" />
+                        }
                       />
                     )}
                   </InputGroup>


### PR DESCRIPTION
This PR blocks the user to move to the next step of the applet creation if the slug isnt valid or is already used 

<img width="781" alt="image" src="https://github.com/Zipper-Inc/zipper-functions/assets/17475188/bf92e315-c877-4ff7-b648-897fc22cb08c">

<img width="747" alt="image" src="https://github.com/Zipper-Inc/zipper-functions/assets/17475188/a9693c57-4317-4461-9c98-d00d9a1754bd">
