### PR TITLE
fixing access control

### DIFF
--- a/apps/zipper.dev/src/server/root.ts
+++ b/apps/zipper.dev/src/server/root.ts
@@ -29,8 +29,10 @@ const enforceAuth = t.middleware(({ ctx, next }) => {
   });
 });
 
-const enforceOrgAdmin = t.middleware(({ ctx, next }) => {
-  if (!ctx.orgId || !hasOrgAdminPermission(ctx)) {
+const enforceOrgAdmin = t.middleware(async ({ ctx, next }) => {
+  const isAdmin = await hasOrgAdminPermission(ctx);
+
+  if (!ctx.orgId || !isAdmin) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
   }
 


### PR DESCRIPTION
This PR is aiming to fix https://app.us.cobalt.io/zipper/zipper-september-2023-pt19512/findings/17

the previous call of `!hasOrgAdminPermission(ctx)` it was always true since it is an asynchronous function and the result was always a Promise

Now it will return the correct value if the user is an admin or not