### PR TITLE
Ariel/missing headers

### DIFF
--- a/apps/zipper.dev/next.config.js
+++ b/apps/zipper.dev/next.config.js
@@ -176,7 +176,7 @@ module.exports = getConfig({
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=86400, immutable',
+            value: 'public, max-age=3600, immutable',
           },
         ],
       },
@@ -185,7 +185,7 @@ module.exports = getConfig({
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=86400, immutable',
+            value: 'public, max-age=3600, immutable',
           },
         ],
       },
@@ -194,7 +194,7 @@ module.exports = getConfig({
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=86400, immutable',
+            value: 'public, max-age=3600, immutable',
           },
         ],
       },
@@ -203,7 +203,16 @@ module.exports = getConfig({
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=86400, immutable',
+            value: 'public, max-age=3600, immutable',
+          },
+        ],
+      },
+      {
+        source: '/public/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=3600, immutable',
           },
         ],
       },


### PR DESCRIPTION
This PR is adding missing security response headers in order to fix [this vulnerability](https://app.us.cobalt.io/zipper/zipper-september-2023-pt19512/findings/1)
<img width="872" alt="image" src="https://github.com/Zipper-Inc/zipper-functions/assets/17475188/613a9ced-656d-4fec-bcb3-9eee100e193f">
