### PR TITLE
fixing permissions checks

### DIFF
--- a/apps/zipper.dev/src/server/routers/appEditor.router.ts
+++ b/apps/zipper.dev/src/server/routers/appEditor.router.ts
@@ -119,14 +119,13 @@ export const appEditorRouter = createTRPCRouter({
        * For pagination you can have a look at this docs site
        * @link https://trpc.io/docs/useInfiniteQuery
        */
+      const canEdit = await !hasAppEditPermission({
+        ctx,
+        appId: input.appId,
+      });
 
       // if it is a private app we should test for the canUserEdit
-      if (
-        !hasAppEditPermission({
-          ctx,
-          appId: input.appId,
-        })
-      ) {
+      if (!canEdit) {
         return {};
       }
 


### PR DESCRIPTION
this PR is fixing unauthenticated users was still able to return the appEditors list for a applet without having edit permission

![image](https://github.com/Zipper-Inc/zipper-functions/assets/17475188/452302cb-4689-4278-b9af-fdb192f57cc0)
