### PR TITLE
Use app.id instead of script.id when hashing scripts

### DIFF
--- a/apps/zipper.dev/src/server/routers/app.router.ts
+++ b/apps/zipper.dev/src/server/routers/app.router.ts
@@ -232,7 +232,7 @@ export const appRouter = createTRPCRouter({
         const scriptHash = getScriptHash({
           code: aiCode ?? defaultCode,
           filename: defaultMainFilename,
-          id: scriptMain.scriptId,
+          appId: app.id,
         });
         const script = await prisma.script.update({
           where: {
@@ -889,7 +889,7 @@ export const appRouter = createTRPCRouter({
                   ...data,
                   isRunnable,
                   hash: getScriptHash({
-                    id,
+                    appId: app.id,
                     filename: filenames[id]!,
                     code: data.code!,
                   }),
@@ -1089,7 +1089,7 @@ async function forkApplet({
           id: newId,
           appId: fork.id,
           order: i,
-          hash: getScriptHash({ ...script, id: newId }),
+          hash: getScriptHash({ ...script, appId: fork.id }),
         },
       });
 

--- a/apps/zipper.dev/src/utils/hashing.ts
+++ b/apps/zipper.dev/src/utils/hashing.ts
@@ -4,11 +4,12 @@ import hash from 'object-hash';
 const APP_VERSION_LENGTH = 7;
 
 export function getScriptHash(
-  script: Pick<Script, 'id' | 'filename' | 'code'>,
+  script: Pick<Script, 'appId' | 'filename' | 'code'>,
 ) {
-  const { id, filename, code } = script;
+  const { appId, filename, code } = script;
+
   return hash(
-    { id, filename, code },
+    { appId, filename, code },
     {
       algorithm: 'sha1',
     },
@@ -17,16 +18,16 @@ export function getScriptHash(
 
 export function getAppHash(
   app: Pick<App, 'id' | 'slug'> & {
-    scripts: Pick<Script, 'id' | 'hash'>[];
+    scripts: Pick<Script, 'filename' | 'hash'>[];
   },
 ) {
   const scripts = JSON.stringify(
     app.scripts
-      .map(({ id, hash }) => ({
-        id,
+      .map(({ filename, hash }) => ({
+        filename,
         hash,
       }))
-      .sort((a, b) => (a.id > b.id ? 1 : -1)),
+      .sort((a, b) => (a.filename > b.filename ? 1 : -1)),
   );
 
   return hash(
@@ -39,7 +40,7 @@ export function getAppHash(
 
 export function getAppHashAndVersion(
   app: Pick<App, 'id' | 'slug'> & {
-    scripts: Pick<Script, 'id' | 'hash'>[];
+    scripts: Pick<Script, 'filename' | 'hash'>[];
   },
 ) {
   const hash = getAppHash(app);


### PR DESCRIPTION
This prevents issues where files with the same code + filename in the same app have different hashes. This happens when specifically when restoring an older version of code. 