### PR TITLE
Improved handler parsing

### DIFF
--- a/apps/zipper.dev/src/utils/parse-code.ts
+++ b/apps/zipper.dev/src/utils/parse-code.ts
@@ -283,12 +283,13 @@ export function parseInputForTypes({
     const inputs = handlerFn.getParameters();
     const params = inputs[0] as ParameterDeclaration;
 
-    if (!params) {
+    if (!params || params.getText().startsWith('_')) {
       return [];
     }
 
     const typeNode = params.getTypeNode();
-    if (typeNode?.isKind(SyntaxKind.AnyKeyword)) {
+
+    if (!typeNode || typeNode?.isKind(SyntaxKind.AnyKeyword)) {
       return [
         {
           key: params.getName(),


### PR DESCRIPTION
## Fix a long standing bugs for valid handler definitions

This used to error if you did not define a type for your inputs. Now it just assumes `any`.
```
export function handler(inputs) {}
```

This also used to break but is totally valid now
```
export const handler = function() {}
```

## Parsing improvements
You can also use  `_` to denote an unused inputs. 
```
export function handler(_inputs, context) {}
```
The new stuff is that we also supports wrapped handlers like
```
const handler = withStack(() => {})
```
Handlers that ref another function
```
const handler = anotherFunc;
```