### PR TITLE
Allow some handlebars templates in Readme

### DIFF
--- a/apps/zipper.dev/src/components/playground/tab-code.tsx
+++ b/apps/zipper.dev/src/components/playground/tab-code.tsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { Script } from '@prisma/client';
 import { Markdown, useCmdOrCtrl } from '@zipper/ui';
+import { useSession } from 'next-auth/react';
 import dynamic from 'next/dynamic';
 import { useEffect, useRef, useState } from 'react';
 import { FiEye } from 'react-icons/fi';
@@ -27,6 +28,7 @@ import {
 } from '~/components/context/help-mode-context';
 import { AppEditSidebar } from '~/components/playground/app-edit-sidebar';
 import { ConnectorId } from '~/connectors/createConnector';
+import { useUser } from '~/hooks/use-user';
 import { AppQueryOutput } from '~/types/trpc';
 import { getOrCreateScriptModel } from '~/utils/playground.utils';
 import { useEditorContext } from '../context/editor-context';
@@ -72,6 +74,7 @@ export const CodeTab: React.FC<CodeTabProps> = ({ app, mainScript }) => {
 
   const { hoveredElement } = useHelpMode();
   const { style, onMouseEnter, onMouseLeave } = useHelpBorder();
+  const { user } = useUser();
 
   // Even though we don't return anything here
   // This hook will force a re-render when the breakpoint changes
@@ -241,7 +244,13 @@ export const CodeTab: React.FC<CodeTabProps> = ({ app, mainScript }) => {
                 },
               }}
             >
-              <Markdown children={getMarkdownBody()} />
+              <Markdown
+                children={getMarkdownBody()}
+                appInfo={{ name: app.name || app.slug, slug: app.slug }}
+                currentUser={{
+                  username: user?.username || 'Anonymous',
+                }}
+              />
             </VStack>
           )}
 

--- a/apps/zipper.dev/src/pages/gallery/[resource-owner]/[app-slug]/index.tsx
+++ b/apps/zipper.dev/src/pages/gallery/[resource-owner]/[app-slug]/index.tsx
@@ -32,6 +32,7 @@ import { trpc } from '~/utils/trpc';
 import { isReadme } from '~/utils/playground.utils';
 import type { MonacoEditor } from '~/components/playground/playground-editor';
 import { AnalyticsHead } from '@zipper/utils';
+import { useUser } from '~/hooks/use-user';
 
 const EDITOR_OPTIONS = {
   fixedOverflowWidgets: true,
@@ -61,6 +62,7 @@ const AppletLandingPage: NextPageWithLayout = () => {
     Script | undefined
   >(undefined);
   const [isBoxVisible, setIsBoxVisible] = useState(true);
+  const { user } = useUser();
 
   const theme = useColorModeValue('vs', 'vs-dark');
 
@@ -165,7 +167,10 @@ const AppletLandingPage: NextPageWithLayout = () => {
                 }}
               />
               <Stack pt={4}>
-                <Markdown>
+                <Markdown
+                  appInfo={{ name: data.name || data.slug, slug: data.slug }}
+                  currentUser={{ username: user?.username || 'Anonymous' }}
+                >
                   {getScriptCode('readme.md') ?? 'No readme found'}
                 </Markdown>
               </Stack>

--- a/packages/@zipper-ui/src/components/function-output/markdown.tsx
+++ b/packages/@zipper-ui/src/components/function-output/markdown.tsx
@@ -3,10 +3,38 @@ import remarkGfm from 'remark-gfm';
 import ChakraUIRenderer from '../../utils/chakra-markdown-renderer';
 import React from 'react';
 
-export const Markdown = ({ children }: { children: string }) => (
-  <ReactMarkdown
-    components={ChakraUIRenderer()}
-    children={children}
-    remarkPlugins={[remarkGfm as any]}
-  />
-);
+export const Markdown = ({
+  children,
+  appInfo,
+  currentUser,
+}: {
+  children: string;
+  appInfo?: { slug: string; name: string };
+  currentUser?: { username: string };
+}) => {
+  let content = children;
+  const appMap = {
+    '{{appName}}': 'name',
+    '{{appSlug}}': 'slug',
+  };
+
+  if (appInfo) {
+    content = content.replace(/({{)(appName|appSlug)(}})/gi, (matched) => {
+      return appInfo[
+        appMap[matched as keyof typeof appMap] as keyof typeof appInfo
+      ];
+    });
+  }
+
+  if (currentUser) {
+    content = content.replace(/({{)(username)(}})/gi, currentUser.username);
+  }
+
+  return (
+    <ReactMarkdown
+      components={ChakraUIRenderer()}
+      children={content}
+      remarkPlugins={[remarkGfm as any]}
+    />
+  );
+};


### PR DESCRIPTION
You can now include {{appSlug}}, {{appName}}, and {{username}} in your Markdown and we'll fill it in correctly when viewing the Readme file in the playground or the gallery landing page. 