### PR TITLE
updateUserSlug: remove resourceOwner guard call

### DIFF
--- a/apps/zipper.dev/src/server/routers/user.router.ts
+++ b/apps/zipper.dev/src/server/routers/user.router.ts
@@ -277,21 +277,6 @@ export const userRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const user = await prisma.user.findUniqueOrThrow({
-        where: {
-          id: ctx.userId,
-        },
-      });
-
-      await prisma.resourceOwnerSlug.update({
-        where: {
-          slug: user.slug,
-        },
-        data: {
-          resourceOwnerId: null,
-        },
-      });
-
       await prisma.resourceOwnerSlug.create({
         data: {
           slug: input.slug,


### PR DESCRIPTION
Removes the logic blocking the username before the update call
Possible fix for #591