### PR TITLE
boot info should return for all apps that don't require auth to run

### DIFF
--- a/apps/zipper.dev/src/pages/api/bootInfo/[slug].ts
+++ b/apps/zipper.dev/src/pages/api/bootInfo/[slug].ts
@@ -5,7 +5,7 @@ import { getBootInfoWithUserInfo } from '~/utils/boot-info-utils';
 const handler: NextApiHandler = async (req, res) => {
   try {
     const data = await getBootInfoWithUserInfo(req, res);
-    if (data?.app && (!data.app.isPrivate || data.app.canUserEdit)) {
+    if (data?.app && (!data.app.requiresAuthToRun || data.app.canUserEdit)) {
       res.status(200).json({ ok: true, data });
     } else {
       res.status(404).json({ ok: false, error: NOT_FOUND });

--- a/apps/zipper.dev/src/pages/api/slack/slash-command.ts
+++ b/apps/zipper.dev/src/pages/api/slack/slash-command.ts
@@ -2,7 +2,6 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import {
   acknowledgeSlack,
   fetchBootInfo,
-  buildFilenameSelect,
   buildSlackModalView,
   openSlackModal,
   buildPrivateMetadata,

--- a/apps/zipper.dev/src/pages/api/slack/utils.ts
+++ b/apps/zipper.dev/src/pages/api/slack/utils.ts
@@ -388,6 +388,8 @@ export function buildRunResultView(
     runId.split('-')[0]
   }`;
 
+  console.log('IMAGE_URL: ', getScreenshotUrl(runUrl));
+
   const resultsBlocks: any[] = [
     {
       type: 'image',

--- a/packages/@zipper-utils/src/utils/get-screenshot-url.ts
+++ b/packages/@zipper-utils/src/utils/get-screenshot-url.ts
@@ -1,7 +1,7 @@
 export function getScreenshotUrl(urlToScreenshot: string): string {
   const imgUrl = new URL(
     process.env.NEXT_PUBLIC_ZIPPER_SCREENSHOTS_URL ||
-      'https://screenshots.zipper.run',
+      'https://screenshots.zipper.run/main.ts',
   );
   imgUrl.searchParams.set('url', urlToScreenshot);
   imgUrl.searchParams.set('format', 'png');


### PR DESCRIPTION
@imadha not sure why I only hit this bug now (I've been on main for a few hours). Looks like bootInfo/[slug] was 404'ing for any app that was private (even though you don't need auth to run the app). 