### PR TITLE
Zipper.storage.get(k) should return undefined if k doesn't have a value set 

### DIFF
--- a/apps/zipper.dev/src/pages/api/app/[appId]/storage.ts
+++ b/apps/zipper.dev/src/pages/api/app/[appId]/storage.ts
@@ -38,7 +38,7 @@ export default async function handler(
     case 'GET': {
       const k = query.key as string;
       if (k && datastore) {
-        res.send({ key: k, value: datastore[k] || '' });
+        res.send({ key: k, value: datastore[k] || undefined });
         break;
       }
       res.send(datastore || {});

--- a/packages/@zipper-framework/deno/zipper.d.ts
+++ b/packages/@zipper-framework/deno/zipper.d.ts
@@ -427,7 +427,7 @@ declare namespace Zipper {
   export interface Storage<Value extends Serializable = Serializable> {
     appId: string;
     getAll<V extends Value = Value>(): Promise<{ [k: string]: V }>;
-    get<V extends Value = Value>(key: string): Promise<V>;
+    get<V extends Value = Value>(key: string): Promise<V> | undefined;
     set<V extends Value = Value>(
       key: string,
       value: V,


### PR DESCRIPTION
Getting a key without a value should return undefined and not an empty string