### PR TITLE
Make the jwt on zipper.run last for 1 hour

### DIFF
--- a/apps/zipper.dev/src/utils/jwt-utils.ts
+++ b/apps/zipper.dev/src/utils/jwt-utils.ts
@@ -1,12 +1,9 @@
 import { User } from '@prisma/client';
 import { JwtPayload, sign, verify } from 'jsonwebtoken';
 import { Session } from 'next-auth';
-import {
-  SessionOrganizationMembership,
-  SessionUser,
-} from '~/pages/api/auth/[...nextauth]';
+import { SessionOrganizationMembership } from '~/pages/api/auth/[...nextauth]';
 
-const JWT_ACCESS_TOKEN_EXPIRY = '15m';
+const JWT_ACCESS_TOKEN_EXPIRY = '1h';
 const JWT_REFRESH_TOKEN_EXPIRY = '7d';
 
 export const generateAccessToken = (


### PR DESCRIPTION
Noticed that if you spent more than 15min on a zipper.run page and then tried to use an action, the action would fail with an unauthed error. This doesn't fix the underlying problem but makes it much less likely to occur