### PR TITLE
Add api endpoints for listing and creating orgs

### DIFF
--- a/apps/zipper.dev/src/components/context/editor-context.tsx
+++ b/apps/zipper.dev/src/components/context/editor-context.tsx
@@ -681,7 +681,7 @@ const EditorContextProvider = ({
   };
 
   const setModelHasErrors = (path: string, hasErrors: boolean) => {
-    if (path === 'types/zipper.d') return;
+    if (path === 'types/zipper.d' || path === 'types/deno.d') return;
     setModelsErrorState((previousModelErrorState) => {
       const newModelState = { ...previousModelErrorState };
       newModelState[path] = hasErrors;

--- a/apps/zipper.dev/src/components/context/run-app-context.tsx
+++ b/apps/zipper.dev/src/components/context/run-app-context.tsx
@@ -389,7 +389,7 @@ export function RunAppProvider({
         },
         { badgeStyle: { background: PRETTY_LOG_TOKENS['purple']! } },
       ),
-      safeJSONParse(result.result, undefined, result.result) || undefined,
+      // safeJSONParse(result.result, undefined, result.result) || undefined,
     ]);
 
     cleanUpLogTimers();

--- a/apps/zipper.dev/src/pages/api/organizations/[orgId]/index.ts
+++ b/apps/zipper.dev/src/pages/api/organizations/[orgId]/index.ts
@@ -1,0 +1,85 @@
+import { prisma } from '~/server/prisma';
+import { HttpMethod as Method, HttpStatusCode as Status } from '@zipper/types';
+import {
+  createApiHandler,
+  methodNotAllowed,
+  simpleErrorResponse,
+  successResponse,
+} from '~/server/utils/api.utils';
+import {
+  hasOrgAdminPermission,
+  hasOrgMemberPermission,
+} from '~/server/utils/authz.utils';
+import { organizationRouter } from '~/server/routers/organization.router';
+
+export default createApiHandler(async (req, res, context) => {
+  const orgId = req.query.orgId as string;
+
+  const contextWithOrgId = { ...context, orgId };
+
+  if (!orgId) {
+    return simpleErrorResponse({
+      res,
+      status: Status.BAD_REQUEST,
+      message: 'Missing organization id',
+    });
+  }
+
+  switch (req.method) {
+    // READ
+    case Method.GET: {
+      const isMember = await hasOrgMemberPermission(contextWithOrgId);
+      console.log(isMember);
+      if (!isMember)
+        return simpleErrorResponse({
+          res,
+          status: Status.UNAUTHORIZED,
+          message: 'Unauthorized',
+        });
+
+      const organization = await prisma.organization.findFirst({
+        where: { id: orgId },
+      });
+
+      return successResponse({
+        res,
+        body: {
+          ok: true,
+          data: { organization },
+        },
+      });
+    }
+
+    // UPDATE
+    case Method.PATCH:
+    case Method.POST:
+    case Method.PUT: {
+      const isAdmin = await hasOrgAdminPermission(contextWithOrgId);
+      if (!isAdmin)
+        return simpleErrorResponse({
+          res,
+          status: Status.UNAUTHORIZED,
+          message: 'Unauthorized',
+        });
+
+      const caller = organizationRouter.createCaller(contextWithOrgId);
+      const updatedOrg = await caller.update({
+        name: req.body.name,
+      });
+
+      return successResponse({
+        res,
+        body: {
+          ok: true,
+          data: {
+            updated: true,
+            organization: updatedOrg,
+          },
+        },
+      });
+    }
+
+    default:
+      return methodNotAllowed({ method: req.method, res });
+  }
+});

--- a/apps/zipper.dev/src/pages/api/organizations/index.ts
+++ b/apps/zipper.dev/src/pages/api/organizations/index.ts
@@ -1,0 +1,100 @@
+import { prisma } from '~/server/prisma';
+import { HttpMethod as Method, HttpStatusCode as Status } from '@zipper/types';
+import {
+  methodNotAllowed,
+  ApiError,
+  successResponse,
+  createApiHandler,
+  errorResponse,
+} from '~/server/utils/api.utils';
+import { Organization, ResourceOwnerSlug } from '@prisma/client';
+import { organizationRouter } from '~/server/routers/organization.router';
+
+type OrgToCreate = { name: string; slug?: string };
+
+type CreateOrgsData = {
+  created: true;
+  organization: Organization;
+  resourceOwnerSlug?: ResourceOwnerSlug;
+};
+
+export default createApiHandler(async (req, res, context) => {
+  const errors: ApiError[] = [];
+  if (!context.userId) errors.push({ message: 'Unauthorized' });
+
+  switch (req.method) {
+    // CREATE
+    case Method.PATCH:
+    case Method.POST:
+    case Method.PUT: {
+      const org: OrgToCreate = req.body;
+
+      if (!org.name) errors.push({ message: 'Organization must have a name' });
+
+      if (errors.length) {
+        return errorResponse({
+          res,
+          body: {
+            ok: false,
+            errors,
+          },
+          status: Status.BAD_REQUEST,
+        });
+      }
+
+      const caller = organizationRouter.createCaller(context);
+      const createdOrg = await caller.add({
+        ...org,
+        shouldCreateResourceOwnerSlug: true,
+      });
+
+      const data: CreateOrgsData = {
+        created: true,
+        organization: createdOrg,
+      };
+
+      data.resourceOwnerSlug = await prisma.resourceOwnerSlug.findFirstOrThrow({
+        where: {
+          resourceOwnerId: createdOrg.id,
+        },
+      });
+
+      return successResponse({
+        res,
+        body: { ok: true, data },
+      });
+    }
+
+    case Method.GET: {
+      if (errors.length) {
+        return errorResponse({
+          res,
+          body: {
+            ok: false,
+            errors,
+          },
+          status: Status.BAD_REQUEST,
+        });
+      }
+
+      const organizationsMemberships =
+        await prisma.organizationMembership.findMany({
+          where: { userId: context.userId },
+          include: { organization: true },
+        });
+
+      return successResponse({
+        res,
+        body: {
+          ok: true,
+          data: {
+            organizations: organizationsMemberships.map((m) => m.organization),
+          },
+        },
+      });
+    }
+
+    default:
+      return methodNotAllowed({ method: req.method, res });
+  }
+});

--- a/apps/zipper.dev/src/server/utils/api.utils.ts
+++ b/apps/zipper.dev/src/server/utils/api.utils.ts
@@ -1,0 +1,188 @@
+import { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
+import { HttpMethod as Method, HttpStatusCode as Status } from '@zipper/types';
+import { safeJSONParse } from '@zipper/utils';
+import { Context } from '../context';
+
+import { verifyAccessToken } from '~/utils/jwt-utils';
+
+type BaseBody = {
+  ok: boolean;
+  meta?: Record<string, Zipper.Serializable>;
+};
+export type ApiError = {
+  message: string;
+  longMessage?: string;
+  code?: string | number;
+};
+
+type SuccessBody = BaseBody & { ok: true; data: Zipper.Serializable };
+type ErrorBody = BaseBody & { ok: false; errors: ApiError[] };
+
+type ApiResponder<B extends BaseBody = SuccessBody> = ({
+  res,
+  body,
+  status,
+}: {
+  res: NextApiResponse<B>;
+  body: B;
+  status?: Status;
+}) => NextApiResponse<B>;
+
+export type SuccessResponse = NextApiResponse<SuccessBody>;
+export type ErrorResponse = NextApiResponse<ErrorBody>;
+
+type ApiHandler<R extends NextApiResponse = SuccessResponse | ErrorResponse> = (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  context: Context,
+) => Promise<R>;
+
+const smartStringify = (obj: any) =>
+  ['number', 'string', 'boolean'].includes(typeof obj)
+    ? obj.toString()
+    : JSON.stringify(obj);
+
+/** Generic success handler for omni API calls */
+export const successResponse: ApiResponder<SuccessBody> = ({
+  res,
+  status = Status.OK,
+  body,
+}) =>
+  res
+    .setHeader('Content-Type', 'application/json')
+    .status(status)
+    .end(smartStringify(body));
+
+/** Generic error handler for omni API calls */
+export const errorResponse: ApiResponder<ErrorBody> = ({
+  res,
+  status = Status.INTERNAL_SERVER_ERROR,
+  body,
+}) =>
+  res
+    .setHeader('Content-Type', 'application/json')
+    .status(status)
+    .end(smartStringify(body));
+
+export const simpleErrorResponse = ({
+  res,
+  status = Status.INTERNAL_SERVER_ERROR,
+  message = 'Internal server error',
+}: {
+  res: NextApiResponse;
+  status: Status;
+  message: string;
+}) =>
+  errorResponse({
+    res,
+    status,
+    body: {
+      ok: false,
+      errors: [{ message, code: status }],
+    },
+  });
+
+/** Error when using an unsupported HTTP method */
+export const methodNotAllowed = ({
+  method = 'method',
+  res,
+}: {
+  method?: string;
+  res: ErrorResponse;
+}) =>
+  errorResponse({
+    res,
+    status: Status.METHOD_NOT_ALLOWED,
+    body: {
+      ok: false,
+      errors: [
+        {
+          message: `Cannot use ${method}`,
+          code: Status.METHOD_NOT_ALLOWED,
+        },
+      ],
+    },
+  });
+
+/** Generic catch all error */
+export const internalServerError = ({
+  req,
+  res,
+  e: caughtError = 'Unknown internal server error',
+}: {
+  req: NextApiRequest;
+  res: ErrorResponse;
+  e: unknown;
+}) =>
+  errorResponse({
+    res,
+    status: Status.INTERNAL_SERVER_ERROR,
+    body: {
+      ok: false,
+      errors: [
+        {
+          message: caughtError?.toString?.() || JSON.stringify(caughtError),
+          code: Status.INTERNAL_SERVER_ERROR,
+        },
+      ],
+      meta: {
+        request: {
+          url: req.url,
+          method: req.method,
+          body: req.body,
+        },
+      },
+    },
+  });
+
+export const methodNeedsBody = (method: unknown) =>
+  [Method.PATCH, Method.POST, Method.PUT].includes(method as Method);
+
+export const unauthorizedError = ({ res }: { res: NextApiResponse }) =>
+  simpleErrorResponse({
+    res,
+    status: Status.UNAUTHORIZED,
+    message: 'Unauthorized',
+  });
+
+/** Wraps an omni handler with auth and stuff */
+export const createApiHandler =
+  (handler: ApiHandler): NextApiHandler =>
+  async (req, res) => {
+    try {
+      const authHeader = req.headers['authorization'] as string;
+      const token = authHeader?.split(' ')[1];
+
+      if (!token) {
+        return await handler(req, res, {
+          userId: undefined,
+          orgId: undefined,
+          organizations: undefined,
+          req,
+          session: undefined,
+        });
+      }
+
+      const payload = verifyAccessToken(token);
+
+      // Assert existance of body if trying to make an update
+      if (methodNeedsBody(req.method) && !req.body) {
+        return simpleErrorResponse({
+          res,
+          status: Status.BAD_REQUEST,
+          message: 'Missing body',
+        });
+      }
+
+      req.body = req.body && safeJSONParse(req.body, undefined, req.body);
+      return await handler(req, res, {
+        userId: payload.sub,
+        orgId: undefined,
+        organizations: payload.organizations,
+        req,
+        session: undefined,
+      });
+    } catch (e) {
+      return internalServerError({ req, res, e });
+    }
+  };

--- a/apps/zipper.dev/src/server/utils/authz.utils.ts
+++ b/apps/zipper.dev/src/server/utils/authz.utils.ts
@@ -77,7 +77,7 @@ export const hasAppReadPermission = async ({
   }
 };
 
-export const hasOrgAdminPermission = async (ctx: Context) => {
+const hasOrgPermission = async (permissions: UserRole[], ctx: Context) => {
   try {
     if (!ctx.userId || !ctx.orgId) {
       return false;
@@ -92,11 +92,19 @@ export const hasOrgAdminPermission = async (ctx: Context) => {
       },
     });
 
-    if (orgMem.role === UserRole.Admin) {
+    if (permissions.includes(orgMem.role as UserRole)) {
       return true;
     }
     return false;
   } catch (error) {
     return false;
   }
+};
+
+export const hasOrgAdminPermission = async (ctx: Context) => {
+  return hasOrgPermission([UserRole.Admin], ctx);
+};
+
+export const hasOrgMemberPermission = async (ctx: Context) => {
+  return hasOrgPermission([UserRole.Member, UserRole.Admin], ctx);
 };

--- a/apps/zipper.dev/src/server/utils/omni.utils.ts
+++ b/apps/zipper.dev/src/server/utils/omni.utils.ts
@@ -1,31 +1,20 @@
 import { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
-import { HttpMethod as Method, HttpStatusCode as Status } from '@zipper/types';
+import { HttpStatusCode as Status } from '@zipper/types';
 import { safeJSONParse } from '@zipper/utils';
 import { Context } from '../context';
 import { verifyHmac } from '~/utils/verify-hmac';
-
-type BaseBody = { ok: boolean; meta?: Record<string, Zipper.Serializable> };
-export type OmniApiError = {
-  message: string;
-  longMessage?: string;
-  code?: string | number;
-};
-
-type SuccessBody = BaseBody & { ok: true; data: Zipper.Serializable };
-type ErrorBody = BaseBody & { ok: false; errors: OmniApiError[] };
-
-type OmniResponder<B extends BaseBody = SuccessBody> = ({
-  res,
-  body,
-  status,
-}: {
-  res: NextApiResponse<B>;
-  body: B;
-  status?: Status;
-}) => NextApiResponse<B>;
-
-type SuccessResponse = NextApiResponse<SuccessBody>;
-type ErrorResponse = NextApiResponse<ErrorBody>;
+import {
+  internalServerError,
+  methodNeedsBody,
+  simpleErrorResponse,
+  SuccessResponse,
+  ErrorResponse,
+  successResponse,
+  errorResponse,
+  methodNotAllowed,
+  unauthorizedError,
+  ApiError,
+} from './api.utils';
 
 type OmniHandler<R extends NextApiResponse = SuccessResponse | ErrorResponse> =
   (
@@ -34,114 +23,6 @@ type OmniHandler<R extends NextApiResponse = SuccessResponse | ErrorResponse> =
   ) => Promise<R>;
 
 export const OMNI_USER_ID = '__OMNI__';
-
-const smartStringify = (obj: Zipper.Serializable) =>
-  ['number', 'string', 'boolean'].includes(typeof obj)
-    ? obj!.toString()
-    : JSON.stringify(obj);
-
-/** Generic success handler for omni API calls */
-export const successResponse: OmniResponder<SuccessBody> = ({
-  res,
-  status = Status.OK,
-  body,
-}) =>
-  res
-    .setHeader('Content-Type', 'application/json')
-    .status(status)
-    .end(smartStringify(body));
-
-/** Generic error handler for omni API calls */
-export const errorResponse: OmniResponder<ErrorBody> = ({
-  res,
-  status = Status.INTERNAL_SERVER_ERROR,
-  body,
-}) =>
-  res
-    .setHeader('Content-Type', 'application/json')
-    .status(status)
-    .end(smartStringify(body));
-
-export const simpleErrorResponse = ({
-  res,
-  status = Status.INTERNAL_SERVER_ERROR,
-  message = 'Internal server error',
-}: {
-  res: NextApiResponse;
-  status: Status;
-  message: string;
-}) =>
-  errorResponse({
-    res,
-    status,
-    body: {
-      ok: false,
-      errors: [{ message, code: status }],
-    },
-  });
-
-/** Error when using an unsupported HTTP method */
-export const methodNotAllowed = ({
-  method = 'method',
-  res,
-}: {
-  method?: string;
-  res: ErrorResponse;
-}) =>
-  errorResponse({
-    res,
-    status: Status.METHOD_NOT_ALLOWED,
-    body: {
-      ok: false,
-      errors: [
-        {
-          message: `Cannot use ${method}`,
-          code: Status.METHOD_NOT_ALLOWED,
-        },
-      ],
-    },
-  });
-
-/** Generic catch all error */
-export const internalServerError = ({
-  req,
-  res,
-  e: caughtError = 'Unknown internal server error',
-}: {
-  req: NextApiRequest;
-  res: ErrorResponse;
-  e: unknown;
-}) =>
-  errorResponse({
-    res,
-    status: Status.INTERNAL_SERVER_ERROR,
-    body: {
-      ok: false,
-      errors: [
-        {
-          message: caughtError?.toString?.() || JSON.stringify(caughtError),
-          code: Status.INTERNAL_SERVER_ERROR,
-        },
-      ],
-      meta: {
-        request: {
-          url: req.url,
-          method: req.method,
-          body: req.body,
-        },
-      },
-    },
-  });
-
-export const methodNeedsBody = (method: unknown) =>
-  [Method.PATCH, Method.POST, Method.PUT].includes(method as Method);
-
-export const unauthorizedError = ({ res }: { res: NextApiResponse }) =>
-  simpleErrorResponse({
-    res,
-    status: Status.UNAUTHORIZED,
-    message: 'Unauthorized',
-  });
 
 /** Wraps an omni handler with auth and stuff */
 export const createOmniApiHandler =
@@ -181,3 +62,15 @@ export const getOmniContext = (req: NextApiRequest): Context => ({
   req,
   session: undefined,
 });
+
+export {
+  internalServerError,
+  methodNeedsBody,
+  simpleErrorResponse,
+  unauthorizedError,
+  successResponse,
+  errorResponse,
+  methodNotAllowed,
+};
+
+export type { SuccessResponse, ErrorResponse, ApiError as OmniApiError };


### PR DESCRIPTION
Adding the first round of APIs to power an org dropdown on zipper.run. Not going to merge for now but will keep around because it figures out a bunch of stuff for API endpoints that can be called with a bearer token.