### PR TITLE
zipper.run: allow path without extension

### DIFF
--- a/apps/zipper.run/src/utils/get-boot-info.ts
+++ b/apps/zipper.run/src/utils/get-boot-info.ts
@@ -12,6 +12,7 @@ import {
   getZipperApiUrl,
   noop,
   parseDeploymentId,
+  removeExtension,
   UNAUTHORIZED,
   X_ZIPPER_TEMP_USER_ID,
 } from '@zipper/utils';
@@ -235,16 +236,22 @@ export async function fetchBootPayloadCachedOrThrow({
 }
 
 export async function fetchBootPayloadCachedWithUserInfoOrThrow(
-  params: BootInfoParams & {
+  params: Omit<BootInfoParams, 'filename'> & {
+    path: string;
     bootInfo?: BootInfo;
     bootFetcher?: BootFetcher;
   },
 ): Promise<BootPayload<true>> {
   const bootPayload = await fetchBootPayloadCachedOrThrow(params);
+  const filename = getFilenameFromPath(
+    params.path,
+    bootPayload.bootInfo.runnableScripts,
+  );
 
   // This is the non-cachable part (user specific)
   const result = await fetchExtendedUserInfo({
     ...params,
+    filename,
     bootInfo: params.bootInfo || bootPayload.bootInfo,
   });
 
@@ -267,8 +274,17 @@ export async function fetchBootPayloadCachedWithUserInfoOrThrow(
   };
 }
 
+export const getPathFromFilename = (filename: string) =>
+  removeExtension(filename);
+
+export const getFilenameFromPath = (path: string, runnableScripts: string[]) =>
+  runnableScripts.find(
+    (scriptFilename) => path === removeExtension(scriptFilename),
+  );
+
 export async function fetchBootInfoCachedWithUserOrThrow(
-  params: BootInfoParams & {
+  params: Omit<BootInfoParams, 'filename'> & {
+    path: string;
     bootInfo?: BootInfo;
     bootFetcher?: BootFetcher;
   },

--- a/apps/zipper.run/src/utils/relay-middleware.ts
+++ b/apps/zipper.run/src/utils/relay-middleware.ts
@@ -6,6 +6,8 @@ import fetchBootInfo, {
   fetchBootInfoCachedWithUserOrThrow,
   fetchDeploymentCachedOrThrow,
   fetchBasicUserInfo,
+  getPathFromFilename,
+  getFilenameFromPath,
 } from './get-boot-info';
 import getValidSubdomain from './get-valid-subdomain';
 import { parseRunUrlPath } from '@zipper/utils';
@@ -243,11 +245,6 @@ export async function relayRequest(
   tempUserId =
     tempUserId || request.cookies.get(__ZIPPER_TEMP_USER_ID)?.value.toString();
 
-  let filename = filenamePassedIn || 'main.ts';
-  if (!filename.endsWith('.ts') && !filename.endsWith('.tsx')) {
-    filename = `${filename}.ts`;
-  }
-
   const bootArgs = {
     appId,
     version,
@@ -262,12 +259,16 @@ export async function relayRequest(
     return bootRelayRequest(bootArgs);
   }
 
+  const path = filenamePassedIn
+    ? getPathFromFilename(filenamePassedIn)
+    : 'main';
+
   let bootInfo;
   try {
     bootInfo = await fetchBootInfoCachedWithUserOrThrow({
       subdomain,
       tempUserId,
-      filename,
+      path,
       token,
       deploymentId,
       bootFetcher: async () => {
@@ -352,6 +353,8 @@ export async function relayRequest(
     displayName: '',
     canUserEdit: userInfo.canUserEdit,
   };
+
+  const filename = getFilenameFromPath(path, bootInfo.runnableScripts);
 
   relayBody.path = filename;
 


### PR DESCRIPTION
handler: zipper.ts

previously
`/zipper.ts` -> will match to zipper.ts
`/zipper.tsx` -> doesnt work
`/zipper` -> doesnt work

now
`/zipper.ts` -> will match to zipper.ts
`/zipper.tsx` -> will match to zipper.ts
`/zipper` -> will match to zipper.ts

The redirect works in `zipper.run/<path>`, `zipper.run/run/<path>` and `zipper.run/<path>/api` 

