### PR TITLE
fix(playground): editor preview on first load 

### DIFF
--- a/apps/zipper.dev/src/components/context/editor-context.tsx
+++ b/apps/zipper.dev/src/components/context/editor-context.tsx
@@ -333,8 +333,8 @@ async function runEditorActionsNow({
   setModelIsDirty: (path: string, isDirty: boolean) => void;
   readOnly: boolean;
   shouldFetchImports: boolean;
-}) {
-  if (!monacoRef.current || !isTypescript(currentScript)) return;
+}): Promise<void> {
+  if (!monacoRef.current || !isTypescript(currentScript) || !value) return;
 
   const currentModel = monacoRef.current.editor.getEditors()[0]?.getModel();
 


### PR DESCRIPTION
Fixes issue: https://github.com/Zipper-Inc/zipper-functions/issues/716

The error was caused by a empty string as a parameter to `runEditorActionsNow`, the solution was just to early return when `value` param is a falsy value


https://github.com/Zipper-Inc/zipper-functions/assets/17225358/7f0bc650-63c1-4dc8-bce9-f9fd5d5d91d4

We may improve this solution by suspending the input section with a skeleton while the code didn't finished to load completly