### PR TITLE
fix(playground): Default values overwritten upon reopening with default value

### DIFF
--- a/packages/@zipper-ui/src/components/function-inputs.tsx
+++ b/packages/@zipper-ui/src/components/function-inputs.tsx
@@ -334,6 +334,7 @@ function SingleInput({
   const close = () => {
     lastValue.current = formContext.getValues()[formName];
     formContext.setValue(formName, undefined);
+    formContext.unregister(formName);
     onClose();
   };
 


### PR DESCRIPTION

https://github.com/Zipper-Inc/zipper-functions/assets/17225358/3737cf95-8388-45a3-bb90-c6f4c1d9b7db

